### PR TITLE
Add En Passant Move

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -148,10 +148,8 @@ export default class App extends React.Component {
       }
 
       if(initiator[1] === 'P' && this.state.enPassantAvail) {
-        console.log("Enpassant Detected in Select Move Loop")
         // Loop and find if initiator is empoweredPawn
         for(const coords of this.state.enP_pieces){
-          console.log(coords)
           if(row1 === coords[0] && col1 === coords[1]) { // only ever can have 2 possible, didn't want to fuss with loop
             specialMove = [true, this.state.vulnerablePawn];
           }
@@ -213,9 +211,7 @@ export default class App extends React.Component {
         if(target[1] === 'P' && this.state.enPassantAvail) {
           // Loop and find if initiator is empoweredPawn
           for(const coords of this.state.enP_pieces){
-            console.log(coords)
             if(row2 === coords[0] && col2 === coords[1]) { // only ever can have 2 possible, didn't want to fuss with loop
-              console.log("Powerful Pawn is selected, set special move to true")
               specialMove = [true, this.state.vulnerablePawn];
             }
           }

--- a/src/App.js
+++ b/src/App.js
@@ -37,6 +37,7 @@ export default class App extends React.Component {
       currentMove: -1,  // move counter
       enPassantAvail: false, // holds state
       enP_pieces: [], // pieces capable of enpassant capture
+      vulnerablePawn: [], // in enpassant scenario, the pawn in danger
     };
   }
 
@@ -193,13 +194,14 @@ export default class App extends React.Component {
       const enP_components = this.lib.enPassantCheck(rows,move,initiator);
       const enP_pieces = enP_components[1];
       const enPassantAvail = enP_components[0];
+      const vulnerablePawn = enP_components[2];
 
       let mate = false;
       if(check){
         mate = this.lib.isCheckMate((whiteMove ? 'W': 'B'), rows);
       }
       let currentMove = history.length - 1;
-      this.setState({selected: null, currentMove, rows, moves: [], threats, history, whiteMove, check, mate, alternatives, enPassantAvail, enP_pieces});
+      this.setState({selected: null, currentMove, rows, moves: [], threats, history, whiteMove, check, mate, alternatives, enPassantAvail, enP_pieces, vulnerablePawn});
     }
     else if(target === '-'){ // Selecting an empty space
       return;
@@ -215,7 +217,7 @@ export default class App extends React.Component {
             console.log(coords)
             if(row2 === coords[0] && col2 === coords[1]) { // only ever can have 2 possible, didn't want to fuss with loop
               console.log("Powerful Pawn is selected, set special move to true")
-              specialMove = true;
+              specialMove = [true, this.state.vulnerablePawn];
             }
           }
         }

--- a/src/App.js
+++ b/src/App.js
@@ -208,9 +208,18 @@ export default class App extends React.Component {
       if((this.state.whiteMove && target[0] === 'W')
         || ((!this.state.whiteMove) && target[0] === 'B')){
 
-        if(this.state.enPassantAvail && target[1] === 'P') {
-          specialMove = true;
+
+        if(target[1] === 'P' && this.state.enPassantAvail) {
+          // Loop and find if initiator is empoweredPawn
+          for(const coords of this.state.enP_pieces){
+            console.log(coords)
+            if(row2 === coords[0] && col2 === coords[1]) { // only ever can have 2 possible, didn't want to fuss with loop
+              console.log("Powerful Pawn is selected, set special move to true")
+              specialMove = true;
+            }
+          }
         }
+
         let moves = this.lib.getMoveList(this.state.rows, target, row2, col2, specialMove);
         moves = this.lib.limitValidMoves(this.state.rows, target, row2, col2, moves);
         this.setState({selected: id, moves});

--- a/src/App.js
+++ b/src/App.js
@@ -37,7 +37,7 @@ export default class App extends React.Component {
       currentMove: -1,  // move counter
       enPassantAvail: false, // holds state
       enP_pieces: [], // pieces capable of enpassant capture
-      vulnerablePawn: [], // in enpassant scenario, the pawn in danger
+      vulnerablePawn: [-1,-1], // in enpassant scenario, the pawn in danger
     };
   }
 
@@ -122,7 +122,7 @@ export default class App extends React.Component {
     let id = ev.currentTarget.id;
     let [row2, col2] = this.decodePosition(id);
     let target = rows[row2][col2];
-    let specialMove = false
+    let specialMove = [false, [-1,-1]];
 
     // Selected piece is selected again, "putting a piece back"
     if(id === this.state.selected){
@@ -146,21 +146,14 @@ export default class App extends React.Component {
         // Loop and find if initiator is empoweredPawn
         for(const coords of this.state.enP_pieces){
           console.log(coords)
-          if([row1,col1] === coords) {
-            specialMove = true;
+          if(row1 === coords[0] && col1 === coords[1]) { // only ever can have 2 possible, didn't want to fuss with loop
+            specialMove = [true, this.state.vulnerablePawn];
           }
         }
       }
-      /*
-      if(this.state.enPassantAvail && initiator[1] === 'P') {
-        let enP_pieces = this.state.enPassantAvail[1];
-        let specialMove = {type: 'enP', pieces: enp_pieces }
-      }
-      */
 
       // TODO: add in check for castle move, and then define special move
       // Probably going to have to special move handling later when that happens
-
 
       let moveList = this.lib.getMoveList(rows, initiator, row1, col1, specialMove);
       moveList = this.lib.limitValidMoves(rows, initiator, row1, col1, moveList);

--- a/src/App.js
+++ b/src/App.js
@@ -184,7 +184,7 @@ export default class App extends React.Component {
       }
       history.push(move);
       rows = this.executeMove(rows, move.from, move.to, specialMove[0]);
-      const threats = this.lib.getThreatMatrix(rows);
+      let threats = this.lib.getThreatMatrix(rows);
       const whiteMove = !this.state.whiteMove;
       const check = this.lib.isKingCheck((whiteMove ? 'W': 'B'), rows);
 
@@ -192,6 +192,12 @@ export default class App extends React.Component {
       const enP_pieces = enP_components[1];
       const enPassantAvail = enP_components[0];
       const vulnerablePawn = enP_components[2];
+
+      // Check done outside of getThreatMatrix
+      // This works, but isn't as clean.
+      if(enPassantAvail) {
+        threats[vulnerablePawn[0]][vulnerablePawn[1]] += enP_pieces.length;
+      }
 
       let mate = false;
       if(check){

--- a/src/App.js
+++ b/src/App.js
@@ -102,12 +102,18 @@ export default class App extends React.Component {
     return [row, col];
   }
 
-  executeMove(rows, from, to){
+  executeMove(rows, from, to,specialMove){
     let [row1, col1] = this.decodePosition(from);
     let [row2, col2] = this.decodePosition(to);
 
     rows[row2][col2] = rows[row1][col1];
     rows[row1][col1] = '-';
+
+    if(this.state.enPassantAvail && specialMove) {
+      rows[this.state.vulnerablePawn[0]][this.state.vulnerablePawn[1]] = '-';
+    }
+    // Pawn Promotion
+    // Technically allowed to promote to Knight, Rook, or Bishop as well
     if(rows[row2][col2][1] === 'P'
        && (row2 === 0 || row2 === 7)){
        const newPiece = rows[row2][col2][0] + 'Q'
@@ -179,7 +185,7 @@ export default class App extends React.Component {
         history = history.slice(0, this.state.currentMove + 1);
       }
       history.push(move);
-      rows = this.executeMove(rows, move.from, move.to);
+      rows = this.executeMove(rows, move.from, move.to, specialMove[0]);
       const threats = this.lib.getThreatMatrix(rows);
       const whiteMove = !this.state.whiteMove;
       const check = this.lib.isKingCheck((whiteMove ? 'W': 'B'), rows);

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ export default class App extends React.Component {
       whiteMove: true,
       check: false,
       mate: false,
-      currentMove: -1,
+      currentMove: -1,  // move counter
     };
   }
 
@@ -58,7 +58,7 @@ export default class App extends React.Component {
       this.playHistory({currentTarget});
     });
   }
- 
+
   renameAlt(ev){
     let index = ev.currentTarget.attributes.index.value;
     let alternatives = this.state.alternatives;
@@ -120,6 +120,7 @@ export default class App extends React.Component {
     let [row2, col2] = this.decodePosition(id);
     let target = rows[row2][col2];
 
+    // Selected piece is selected again, "putting a piece back"
     if(id === this.state.selected){
       this.setState({selected: null, moves: []});
     }
@@ -127,7 +128,7 @@ export default class App extends React.Component {
       let [row1, col1] = this.decodePosition(this.state.selected);
 
       let initiator = rows[row1][col1];
-
+      // if not empty space, validate that move isn't onto initiator color
       if(target !== '-'){
         let targetColor = target[0];
         let initiatorColor = initiator[0];
@@ -145,7 +146,7 @@ export default class App extends React.Component {
           break;
         }
       }
-      if(!found){
+      if(!found){ // move not on movelist
         return;
       }
 
@@ -173,7 +174,7 @@ export default class App extends React.Component {
     else if(target === '-'){
       return;
     }
-    else {
+    else { // Selecting a piece w/ .selected == null
       if((this.state.whiteMove && target[0] === 'W')
         || ((!this.state.whiteMove) && target[0] === 'B')){
         let moves = this.lib.getMoveList(this.state.rows, target, row2, col2);
@@ -211,9 +212,9 @@ export default class App extends React.Component {
         }
       }
       return (
-        <div 
-           className={classList} 
-           id={id} 
+        <div
+           className={classList}
+           id={id}
            onClick={this.select}
         >
           <Piece code={props.piece}/>
@@ -234,7 +235,7 @@ export default class App extends React.Component {
               <span>Alternative sequences: </span>
             }
             {this.state.alternatives.map((alt, altno) =>
-              <span key={'alt_'+altno}><b> &nbsp; &lt; {alt.name} 
+              <span key={'alt_'+altno}><b> &nbsp; &lt; {alt.name}
                 &#x5b;
                 <span className='App-link' index={altno} onClick={this.renameAlt}>&#x2699;</span>
                 |
@@ -246,7 +247,7 @@ export default class App extends React.Component {
               </span>
             )}
         </div>
- 
+
       <div className="App">
 
        <div className="App-sidebar">
@@ -264,7 +265,7 @@ export default class App extends React.Component {
                 }
                 <hr/>
               </div>
- 
+
             {this.state.history.map((move, moveno) =>
               <div
                 key={"move_" + moveno}
@@ -290,7 +291,7 @@ export default class App extends React.Component {
           {this.state.rows.map((row, rownum) =>
             <div key={"row_" + rownum}>
               <div className="cell cell-info">{8-rownum}</div>
-              {row.map((col, colnum) => 
+              {row.map((col, colnum) =>
                 <Cell
                   key={"r_" + rownum + "c_" + colnum}
                   rownum={rownum}
@@ -308,25 +309,24 @@ export default class App extends React.Component {
           }
           {this.state.selected &&
             <div>
-              {this.state.selected} -> 
+              {this.state.selected} ->
             </div>
           }
 
-          <div> 
-            {this.state.whiteMove? "white": "black"} to move 
+          <div>
+            {this.state.whiteMove? "white": "black"} to move
             {this.state.check &&
               <span> - check</span>
             }
             {this.state.mate &&
               <span>mate</span>
             }
- 
+
           </div>
- 
+
         </div>
       </div>
       </div>
     );
   }
 }
-

--- a/src/lib/chess.js
+++ b/src/lib/chess.js
@@ -11,8 +11,10 @@ export default class chess {
     movex = movex + (colorMultiple);
 
     // en passant move
+    // The vulnerable pawn coords are accessible in enPassantAvail[1]
     if(enPassantAvail[0]){
-      console.log("We made it")
+      let enPassCaptureMove = [enPassantAvail[1][0] + (colorMultiple),enPassantAvail[1][1]];
+      moves.push(enPassCaptureMove);
     }
 
     // Move forward one space, if empty and not off board
@@ -411,12 +413,6 @@ export default class chess {
   // This function checks if enPassant will be possible on next turn
   // Also returns the specific move that is possible for the enlightened pawn
   enPassantCheck(rows, move, piece){
-    /*
-    console.log(piece)
-    console.log(move)
-    console.log(rows)
-    */
-
     // Not necessary to proceed if not a pawn Move
     if(piece[1] !== 'P') {
       return false;
@@ -431,7 +427,17 @@ export default class chess {
 
         // Narrow down capture scenario more
         if(piece[0] === 'W' && (adjacents.left === 'BP' || adjacents.right === 'BP')) {
-          return true;
+          const empoweredPawns = [];
+
+          if(adjacents.left === 'WP'){
+            empoweredPawns.push([arrayPosX, arrayPosY-1]);
+          }
+
+          if(adjacents.right === 'WP'){
+            empoweredPawns.push([arrayPosX, arrayPosY+1]);
+          }
+
+          return [true, empoweredPawns, vulnerablePawn];
         }
         else if(piece[0] === 'B' && (adjacents.left === 'WP' || adjacents.right === 'WP')) {
 
@@ -447,10 +453,10 @@ export default class chess {
 
           return [true, empoweredPawns, vulnerablePawn];
         } else { // no surrounding pieces to take vulnerable pawn
-          return false;
+          return [false, [], []];
         }
       } else { // pawn didn't move two spaces
-        return false;
+        return [false, [], []];
       }
     }
   }

--- a/src/lib/chess.js
+++ b/src/lib/chess.js
@@ -1,7 +1,7 @@
 import lo from 'lodash';
 
 export default class chess {
-  getPawnMoveList(rows, piece, x, y){
+  getPawnMoveList(rows, piece, x, y, enPassantAvail){
     // TODO: need to add en-passant
     // Add default to getPawnMoveList, en_passant_poss = false
     const colorMultiple = (piece[0] === 'B' ? 1 : -1);
@@ -9,6 +9,12 @@ export default class chess {
     let movex = x;
     let movey = y;
     movex = movex + (colorMultiple);
+
+    // en passant move
+    console.log(enPassantAvail)
+    if(enPassantAvail){
+      console.log("We made it")
+    }
     if(movex > -1 && movex < 8){
       if(rows[movex][movey] === '-'){
         moves.push([movex,movey]);
@@ -43,6 +49,8 @@ export default class chess {
         moves.push([movex, movey]);
       }
     }
+
+
     return moves;
   }
   getRookMoveList(rows, piece, x, y){
@@ -329,11 +337,11 @@ export default class chess {
   }
 
 
-  getMoveList(rows, piece, x, y){
+  getMoveList(rows, piece, x, y, specialMove = false){
     let moves;
     switch(piece[1]){
       case 'P':
-        moves = this.getPawnMoveList(rows, piece, x, y);
+        moves = this.getPawnMoveList(rows, piece, x, y, specialMove);
         break;
       case 'R':
         moves = this.getRookMoveList(rows, piece, x, y);
@@ -403,7 +411,7 @@ export default class chess {
     console.log(move)
     console.log(rows)
     */
-    
+
     // Not necessary to proceed if not a pawn Move
     if(piece[1] !== 'P') {
       return false;
@@ -421,11 +429,22 @@ export default class chess {
           return true;
         }
         else if(piece[0] === 'B' && (adjacents.left === 'WP' || adjacents.right === 'WP')) {
-          return true;
+
+          const empoweredPawns = [];
+          if(adjacents.left === 'WP'){
+            empoweredPawns.push([arrayPosX, arrayPosY-1]);
+          }
+
+          if(adjacents.right === 'WP'){
+            empoweredPawns.push([arrayPosX, arrayPosY+1]);
+          }
+
+          console.log(empoweredPawns)
+          return [true, empoweredPawns];
         } else { // no surrounding pieces to take vulnerable pawn
           return false;
         }
-      } else {
+      } else { // pawn didn't move two spaces
         return false;
       }
     }

--- a/src/lib/chess.js
+++ b/src/lib/chess.js
@@ -3,6 +3,7 @@ import lo from 'lodash';
 export default class chess {
   getPawnMoveList(rows, piece, x, y){
     // TODO: need to add en-passant
+    // Add default to getPawnMoveList, en_passant_poss = false
     const colorMultiple = (piece[0] === 'B' ? 1 : -1);
     const moves = [];
     let movex = x;
@@ -71,7 +72,7 @@ export default class chess {
       }
       moves.push([movex, movey]);
     }
- 
+
     movex = x;
     movey = y;
     while(++movey < 8){
@@ -96,7 +97,7 @@ export default class chess {
       }
       moves.push([movex, movey]);
     }
- 
+
     return moves;
   }
 
@@ -188,8 +189,8 @@ export default class chess {
         }
       }
     }
- 
-    return moves; 
+
+    return moves;
   }
 
   getBishopMoveList(rows, piece, x, y){
@@ -260,7 +261,7 @@ export default class chess {
       if(target === '-' || target[0] !== piece[0]){
         moves.push([movex, movey]);
       }
- 
+
       if(movey - 1 > -1){
         movey--;
         let target = rows[movex][movey];
@@ -287,7 +288,7 @@ export default class chess {
       if(target === '-' || target[0] !== piece[0]){
         moves.push([movex, movey]);
       }
- 
+
       if(movey - 1 > -1){
         movey--;
         let target = rows[movex][movey];
@@ -322,9 +323,9 @@ export default class chess {
         moves.push([movex, movey]);
       }
     }
-    // TODO need to add castle on kingside and queenside 
+    // TODO need to add castle on kingside and queenside
     // in order to offer this feature need to detect "check" threat
-    return moves; 
+    return moves;
   }
 
 
@@ -392,6 +393,42 @@ export default class chess {
       }
     }
     return false; // technically, could be a pathological setup
+  }
+
+  // This function checks if enPassant will be possible on next turn
+  // Also returns the specific move that is possible for the enlightened pawn
+  enPassantCheck(rows, move, piece){
+    /*
+    console.log(piece)
+    console.log(move)
+    console.log(rows)
+    */
+    
+    // Not necessary to proceed if not a pawn Move
+    if(piece[1] !== 'P') {
+      return false;
+
+    } else { // check if two space move is used
+      if(Math.abs(move.from[1].charCodeAt() - move.to[1].charCodeAt()) === 2){
+        // Check pieces to left and to right
+        // position within array
+        let [arrayPosX,arrayPosY] = [7- (move.to.charCodeAt(1) - 49), move.to.charCodeAt(0) - 65]; // set as x,y. Check decode position in App.js
+        let adjacents = {left: rows[arrayPosX][arrayPosY-1], right: rows[arrayPosX][arrayPosY+1]};
+
+        console.log(adjacents)
+        // Narrow down capture scenario more
+        if(piece[0] === 'W' && (adjacents.left === 'BP' || adjacents.right === 'BP')) {
+          return true;
+        }
+        else if(piece[0] === 'B' && (adjacents.left === 'WP' || adjacents.right === 'WP')) {
+          return true;
+        } else { // no surrounding pieces to take vulnerable pawn
+          return false;
+        }
+      } else {
+        return false;
+      }
+    }
   }
 
   getThreatMatrix(rows){

--- a/src/lib/chess.js
+++ b/src/lib/chess.js
@@ -11,7 +11,7 @@ export default class chess {
     movex = movex + (colorMultiple);
 
     // en passant move
-    if(enPassantAvail){
+    if(enPassantAvail[0]){
       console.log("We made it")
     }
 
@@ -425,10 +425,10 @@ export default class chess {
       if(Math.abs(move.from[1].charCodeAt() - move.to[1].charCodeAt()) === 2){
         // Check pieces to left and to right
         // position within array
-        let [arrayPosX,arrayPosY] = [7- (move.to.charCodeAt(1) - 49), move.to.charCodeAt(0) - 65]; // set as x,y. Check decode position in App.js
-        let adjacents = {left: rows[arrayPosX][arrayPosY-1], right: rows[arrayPosX][arrayPosY+1]};
+        const [arrayPosX,arrayPosY] = [7- (move.to.charCodeAt(1) - 49), move.to.charCodeAt(0) - 65]; // set as x,y. Check decode position in App.js
+        const vulnerablePawn = [arrayPosX,arrayPosY];
+        const adjacents = {left: rows[arrayPosX][arrayPosY-1], right: rows[arrayPosX][arrayPosY+1]};
 
-        console.log(adjacents)
         // Narrow down capture scenario more
         if(piece[0] === 'W' && (adjacents.left === 'BP' || adjacents.right === 'BP')) {
           return true;
@@ -436,6 +436,7 @@ export default class chess {
         else if(piece[0] === 'B' && (adjacents.left === 'WP' || adjacents.right === 'WP')) {
 
           const empoweredPawns = [];
+
           if(adjacents.left === 'WP'){
             empoweredPawns.push([arrayPosX, arrayPosY-1]);
           }
@@ -444,8 +445,7 @@ export default class chess {
             empoweredPawns.push([arrayPosX, arrayPosY+1]);
           }
 
-          console.log(empoweredPawns)
-          return [true, empoweredPawns];
+          return [true, empoweredPawns, vulnerablePawn];
         } else { // no surrounding pieces to take vulnerable pawn
           return false;
         }

--- a/src/lib/chess.js
+++ b/src/lib/chess.js
@@ -429,11 +429,11 @@ export default class chess {
         if(piece[0] === 'W' && (adjacents.left === 'BP' || adjacents.right === 'BP')) {
           const empoweredPawns = [];
 
-          if(adjacents.left === 'WP'){
+          if(adjacents.left === 'BP'){
             empoweredPawns.push([arrayPosX, arrayPosY-1]);
           }
 
-          if(adjacents.right === 'WP'){
+          if(adjacents.right === 'BP'){
             empoweredPawns.push([arrayPosX, arrayPosY+1]);
           }
 

--- a/src/lib/chess.js
+++ b/src/lib/chess.js
@@ -11,15 +11,18 @@ export default class chess {
     movex = movex + (colorMultiple);
 
     // en passant move
-    console.log(enPassantAvail)
     if(enPassantAvail){
       console.log("We made it")
     }
+
+    // Move forward one space, if empty and not off board
     if(movex > -1 && movex < 8){
       if(rows[movex][movey] === '-'){
         moves.push([movex,movey]);
       }
     }
+
+    // Also move forward one space if on starting pawn row
     if(x === 1 || x === 6){
       movex = movex + (colorMultiple);
       if(movex > -1 && movex < 8){
@@ -28,13 +31,15 @@ export default class chess {
         }
       }
     }
+
     movex = x;
     movey = y;
     movex = movex + (colorMultiple);
     if(movex < 0 || movex > 7){
       return moves;
     }
-    if(movey + 1 <= 7){
+
+    if(movey + 1 <= 7){ // Capture Instance
       movey += 1;
       let target = rows[movex][movey];
       if(target !== '-' && target[0] !== piece[0]){
@@ -42,7 +47,7 @@ export default class chess {
       }
     }
     movey = y;
-    if(movey - 1 >= 0){
+    if(movey - 1 >= 0){ // Capture Instance
       movey -= 1;
       let target = rows[movex][movey];
       if(target !== '-' && target[0] !== piece[0]){


### PR DESCRIPTION
Checks for a two space pawn move in the select loop, then verifies if an _en passant_ is possible based on pieces neighboring the moved pawn. If _en passant_ is possible, then the pawns capable of the move, the vulnerable pawn, and the state of _en passant_ availability will be saved to the game state. The availability is set to false if the _en passant_ capture is not made that turn.